### PR TITLE
[CMSP-391][CI] Ensure a cde is available for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,10 +116,11 @@ jobs:
 workflows:
   build:
     jobs:
-      - ensure_multidevs
+      - ensure_multidevs:
+          name: Ensure There are Enough Multidevs
       - build:
           requires:
-            - ensure_multidevs
+            - Ensure There are Enough Multidevs
           matrix:
             parameters:
               base-env: [dev, drupal10]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
             - run:
                 name: login-pantheon
                 command: terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
+            - checkout
             - run: 
                 name: Ensure a multidev is available
                 command: bash .circleci/scripts/ensure-available-multidev.sh "$TERMINUS_SITE"
@@ -26,7 +27,6 @@ jobs:
                     terminus env:create $TERMINUS_SITE.$TERMINUS_BASE_ENV ${CIRCLE_BUILD_NUM} || echo "mystery errors were being thrown by env:create so I am adding this OR (https://circleci.com/gh/pantheon-systems/pantheon_advanced_page_cache/610)"
                     touch multidev-made.txt
                 background: true
-            - checkout
             - run:
                 name: Composer install
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 # https://circleci.com/docs/configuration#machine
+
 jobs:
     build:
         parameters:
@@ -14,6 +15,9 @@ jobs:
             - run:
                 name: login-pantheon
                 command: terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
+            - run: 
+                name: Ensure a multidev is available
+                command: bash .circleci/scripts/ensure-available-multidev.sh "$TERMINUS_SITE"
             # Start making a multidev right away in the background so that
             # this slow step is done as soon as possible.
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             TERMINUS_SITE: d9-papc3
         steps:
             - login-pantheon
+            - checkout
             - run: 
                 name: Ensure enough multidev environments are available
                 command: bash .circleci/scripts/ensure-available-multidev.sh "$TERMINUS_SITE" 2
@@ -32,7 +33,6 @@ jobs:
             TERMINUS_BASE_ENV: << parameters.base-env >>
         steps:
             - login-pantheon
-            - checkout
             # Start making a multidev right away in the background so that
             # this slow step is done as soon as possible.
             - run:
@@ -41,6 +41,7 @@ jobs:
                     terminus env:create $TERMINUS_SITE.$TERMINUS_BASE_ENV ${CIRCLE_BUILD_NUM} || echo "mystery errors were being thrown by env:create so I am adding this OR (https://circleci.com/gh/pantheon-systems/pantheon_advanced_page_cache/610)"
                     touch multidev-made.txt
                 background: true
+            - checkout
             - run:
                 name: Composer install
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,38 @@
 version: 2.1
 # https://circleci.com/docs/configuration#machine
+executors:
+  build-tools:
+    docker:
+      - image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
+
+commands:
+    login-pantheon:
+        steps:
+            - run:
+                name: Login with Terminus
+                command: terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
 
 jobs:
+    ensure_multidevs:
+        executor: build-tools
+        environment:
+            TERMINUS_SITE: d9-papc3
+        steps:
+            - login-pantheon
+            - run: 
+                name: Ensure enough multidev environments are available
+                command: bash .circleci/scripts/ensure-available-multidev.sh "$TERMINUS_SITE" 2
     build:
         parameters:
             base-env:
                 type: string
-        docker:
-            - image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
+        executor: build-tools
         environment:
             TERMINUS_SITE: d9-papc3
             TERMINUS_BASE_ENV: << parameters.base-env >>
         steps:
-            - run:
-                name: login-pantheon
-                command: terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
+            - login-pantheon
             - checkout
-            - run: 
-                name: Ensure a multidev is available
-                command: bash .circleci/scripts/ensure-available-multidev.sh "$TERMINUS_SITE"
             # Start making a multidev right away in the background so that
             # this slow step is done as soon as possible.
             - run:
@@ -101,7 +115,10 @@ jobs:
 workflows:
   build:
     jobs:
+      - ensure_multidevs
       - build:
+          requires:
+            - ensure_multidevs
           matrix:
             parameters:
               base-env: [dev, drupal10]

--- a/.circleci/scripts/ensure-available-multidev.sh
+++ b/.circleci/scripts/ensure-available-multidev.sh
@@ -29,8 +29,10 @@ MAX_CDE_COUNT="$(terminus site:info "${SITE_NAME}" --field='Max Multidevs')"
 echo "Max Multidev Count: ${MAX_CDE_COUNT}"
 
 DOMAINS="$(terminus env:list "${SITE_NAME}" --format=string --fields=ID,Created)"
-# Filter out dev, test, or live
-FILTERED_DOMAINS=$(echo "$DOMAINS" | grep -vE '\b(dev|test|live)\b')
+
+# Filter out dev, test, live, or 'drupal10'.
+# Any other envs that we should avoid deleting should be included in this grep.
+FILTERED_DOMAINS=$(echo "$DOMAINS" | grep -vE '\b(dev|test|live|drupal10)\b')
 
 # Count current environments
 CDE_COUNT="$(echo "$FILTERED_DOMAINS" | wc -l)"

--- a/.circleci/scripts/ensure-available-multidev.sh
+++ b/.circleci/scripts/ensure-available-multidev.sh
@@ -25,6 +25,8 @@ elif ! [[ $NUMBER_OF_CDES_REQUIRED =~ ^[0-9]+$ ]]; then
     usage_exit
 fi
 
+terminus --version
+
 MAX_CDE_COUNT="$(terminus site:info "${SITE_NAME}" --field='Max Multidevs')"
 echo "Max Multidev Count: ${MAX_CDE_COUNT}"
 

--- a/.circleci/scripts/ensure-available-multidev.sh
+++ b/.circleci/scripts/ensure-available-multidev.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+###
+# Given a site name, ensure we can create a new multidev, or delete the oldest one.
+###
+SITE_NAME="${1:-}"
+if [[ -z "${SITE_NAME}" ]];then
+    echo "Missing Site Name"
+    exit 1
+fi
+
+MAX_CDE_COUNT="$(terminus site:info "${SITE_NAME}" --field='Max Multidevs')"
+echo "Max Multidev Count: ${MAX_CDE_COUNT}"
+
+DOMAINS="$(terminus env:list "${SITE_NAME}" --format=string --fields=ID,Created)"
+# Filter out dev, test, or live
+FILTERED_DOMAINS=$(echo "$DOMAINS" | grep -vE '\b(dev|test|live)\b')
+
+# Count current environments
+CDE_COUNT="$(echo "$FILTERED_DOMAINS" | wc -l)"
+# remove whitespace to make the arithmetic work
+CDE_COUNT="${CDE_COUNT//[[:blank:]]/}"
+
+echo "There are currently ${CDE_COUNT}/${MAX_CDE_COUNT} multidevs"
+
+if [[ "${CDE_COUNT}" -lt "${MAX_CDE_COUNT}" ]]; then
+  echo "There are enough multidevs"
+  exit
+fi
+
+echo "There are not enough multidevs, deleting the oldest one."
+
+# Sort the list by the timestamps
+SORTED_DOMAINS=$(echo "$FILTERED_DOMAINS" | sort -n -k2)
+# Extract the top name from the sorted list
+ENV_TO_REMOVE=$(echo "$SORTED_DOMAINS" | head -n 1 | cut -f1)
+terminus multidev:delete --delete-branch "${SITE_NAME}.${ENV_TO_REMOVE}" --yes

--- a/.circleci/scripts/ensure-available-multidev.sh
+++ b/.circleci/scripts/ensure-available-multidev.sh
@@ -43,12 +43,12 @@ echo "There are currently ${CDE_COUNT}/${MAX_CDE_COUNT} multidevs. I need ${NUMB
 
 POTENTIAL_CDE_COUNT=$((CDE_COUNT + NUMBER_OF_CDES_REQUIRED))
 if [[ "${POTENTIAL_CDE_COUNT}" -le "${MAX_CDE_COUNT}" ]]; then
-  echo "There are enough multidevs"
+  echo "There are enough multidevs."
   exit
 fi
 
 NUMBER_OF_CDES_TO_DELETE=$((POTENTIAL_CDE_COUNT - MAX_CDE_COUNT))
-echo "There are not enough multidevs, deleting the oldest ${NUMBER_OF_CDES_TO_DELETE}."
+echo "There are not enough multidevs, deleting the oldest ${NUMBER_OF_CDES_TO_DELETE} environment(s)."
 
 # Sort the list by the timestamps
 SORTED_DOMAINS=$(echo "$FILTERED_DOMAINS" | sort -n -k2)
@@ -56,6 +56,6 @@ SORTED_DOMAINS=$(echo "$FILTERED_DOMAINS" | sort -n -k2)
 # Delete as many multidevs as we need to make room for testing.
 for (( i = 1; i<=NUMBER_OF_CDES_TO_DELETE; i++ )); do
     ENV_TO_REMOVE="$(echo "$SORTED_DOMAINS" | head -n "$i" | tail -n 1 | cut -f1)"
-    echo "Removing ${ENV_TO_REMOVE}"
+    echo "Removing '${ENV_TO_REMOVE}'."
     terminus multidev:delete --delete-branch "${SITE_NAME}.${ENV_TO_REMOVE}" --yes
 done

--- a/.circleci/scripts/ensure-available-multidev.sh
+++ b/.circleci/scripts/ensure-available-multidev.sh
@@ -52,7 +52,7 @@ echo "There are not enough multidevs, deleting the oldest ${NUMBER_OF_CDES_TO_DE
 SORTED_DOMAINS=$(echo "$FILTERED_DOMAINS" | sort -n -k2)
 
 # Delete as many multidevs as we need to make room for testing.
-for (( i = 1; i<=${NUMBER_OF_CDES_TO_DELETE}; i++ )); do
+for (( i = 1; i<=NUMBER_OF_CDES_TO_DELETE; i++ )); do
     ENV_TO_REMOVE="$(echo "$SORTED_DOMAINS" | head -n "$i" | tail -n 1 | cut -f1)"
     echo "Removing ${ENV_TO_REMOVE}"
     terminus multidev:delete --delete-branch "${SITE_NAME}.${ENV_TO_REMOVE}" --yes

--- a/.circleci/scripts/ensure-available-multidev.sh
+++ b/.circleci/scripts/ensure-available-multidev.sh
@@ -46,16 +46,13 @@ if [[ "${POTENTIAL_CDE_COUNT}" -le "${MAX_CDE_COUNT}" ]]; then
   exit
 fi
 
+NUMBER_OF_CDES_TO_DELETE=$((POTENTIAL_CDE_COUNT - MAX_CDE_COUNT))
+echo "There are not enough multidevs, deleting the oldest ${NUMBER_OF_CDES_TO_DELETE} environment(s)."
+
 # Filter out any multidev environments that should never be deleted.
 # This is seperate from filtering out dev/test/live above as they still count towards 'Max Multidev'.
 # Then, sort the list by the timestamps
 SORTED_DOMAINS=$(echo "$CDE_DOMAINS" | grep -vE '\b(drupal10)\b' | sort -n -k2)
-echo "Domains safe to delete:"
-echo $SORTED_DOMAINS
-echo
-
-NUMBER_OF_CDES_TO_DELETE=$((POTENTIAL_CDE_COUNT - MAX_CDE_COUNT))
-echo "There are not enough multidevs, deleting the oldest ${NUMBER_OF_CDES_TO_DELETE} environment(s)."
 
 # Delete as many multidevs as we need to make room for testing.
 for (( i = 1; i<=NUMBER_OF_CDES_TO_DELETE; i++ )); do


### PR DESCRIPTION
Before running tests that require creating a multidev, ensure there are available multidev slots, or delete the oldest ones.