### PR TITLE
[SITE-1855] Declare Drupal 11 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,4 +123,4 @@ workflows:
             - Ensure There are Enough Multidevs
           matrix:
             parameters:
-              base-env: [dev, drupal10]
+              base-env: [dev, drupal10, drupal11]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,4 +123,4 @@ workflows:
             - Ensure There are Enough Multidevs
           matrix:
             parameters:
-              base-env: [dev, drupal10, drupal11]
+              base-env: [dev, drupal10]

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -18,7 +18,7 @@ git checkout -b $TERMINUS_ENV
 # git clone command above.
 composer update "pantheon-upstreams/upstream-configuration"
 
-composer -- config repositories.papc vcs git@github.com:pantheon-systems/pantheon_advanced_page_cache.git
+composer -- config repositories.papc vcs https://github.com/pantheon-systems/pantheon_advanced_page_cache.git
 
 # dev-2.x does not match anything, should be 2.x-dev as per https://getcomposer.org/doc/articles/aliases.md#branch-alias.
 export BRANCH_PART="dev-${CIRCLE_BRANCH}"

--- a/pantheon_advanced_page_cache.info.yml
+++ b/pantheon_advanced_page_cache.info.yml
@@ -2,4 +2,5 @@ name: Pantheon Advanced Page Cache
 description: 'Advanced page cache capabilities for Pantheon.'
 package: Performance and scalability
 type: module
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.4 || ^10 || ^11
+

--- a/tests/behat/features/huge_header_warning.feature
+++ b/tests/behat/features/huge_header_warning.feature
@@ -5,7 +5,6 @@ I need a notification when my header is truncated.
 
   @api
   Scenario: Warning message.
-    Given I run drush "pm-uninstall -y pantheon_advanced_page_cache_test"
     Given I run drush "en -y pantheon_advanced_page_cache"
     And I am logged in as a user with the "administrator" role
 

--- a/tests/behat/features/override_list_tag.feature
+++ b/tests/behat/features/override_list_tag.feature
@@ -6,7 +6,8 @@ I want to toggle the setting for overriding cache tags
   @api
   Scenario: Core behavior
     Given there are some "article" nodes
-    And "/" is caching
+    When I visit "/"
+    Then "/" is caching
     When a generate a "article" node
     Then "/" has been purged
     And "/" is caching
@@ -15,7 +16,7 @@ I want to toggle the setting for overriding cache tags
   Scenario: Old override
     Given there are some "article" nodes
     When I run drush "config:set pantheon_advanced_page_cache.settings --input-format=yaml   override_list_tags true"
-    And "/" is caching
+    And I visit "/"
+    Then "/" is caching
     When a generate a "article" node
-    And "/" has not been purged
-
+    Then "/" has not been purged

--- a/tests/modules/pantheon_advanced_page_cache_test/pantheon_advanced_page_cache_test.info.yml
+++ b/tests/modules/pantheon_advanced_page_cache_test/pantheon_advanced_page_cache_test.info.yml
@@ -2,4 +2,4 @@ name: Pantheon Advanced Page Cache Test
 description: 'Used during automated test of Pantheon Advanced Page Cache'
 package: Testing
 type: module
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.4 || ^10 || ^11


### PR DESCRIPTION
This PR is based on the patch submitted via the [project-update-bot](https://www.drupal.org/project/pantheon_advanced_page_cache/issues/3438549) on drupal.org.

Pantheon Advanced Page Cache does the following things:

- It registers a cache tags invalidator (Drupal\Core\Cache\CacheTagsInvalidatorInterface)
- It registers an event subscriber (Symfony\Component\EventDispatcher\EventSubscriberInterface)
- It implements hook_ENTITY_TYPE_update()

We know the following:

- CacheTagsInvalidatorInterface did not change between Drupal 10.x and Drupal 11.x
- EventSubscriberInterface did not change between Symfony 6.4 and 7
- The hook and entity system did not change in Drupal 11

This gives us some level of confidence that this level of change should be sufficient for Drupal 11 compatibility, and, in fact, this module [does install on a Drupal 11 site](https://admin.dashboard.pantheon.io/sites/c4d0053f-3dd8-49fb-ae1a-b3cfcc6dfaa6#dev/code).

Tests are currently failing, though, and it would be good to have some level of actual testing done here before assuming we are done.