### PR TITLE
[SITE-1855] Drupal 11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
             - run:
                 name: site install
                 command: |
-                  terminus build:workflow:wait ${TERMINUS_SITE}.${CIRCLE_BUILD_NUM}
+                  terminus build:workflow:wait ${TERMINUS_SITE}.${CIRCLE_BUILD_NUM} --max=300
                   terminus connection:set ${TERMINUS_SITE}.${CIRCLE_BUILD_NUM} sftp
                   terminus env:wake ${TERMINUS_SITE}.${CIRCLE_BUILD_NUM}
                   terminus drush ${TERMINUS_SITE}.${CIRCLE_BUILD_NUM} -- site-install -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,4 +123,4 @@ workflows:
             - Ensure There are Enough Multidevs
           matrix:
             parameters:
-              base-env: [dev, drupal10]
+              base-env: [dev, drupal10, drupal11]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,4 +123,4 @@ workflows:
             - Ensure There are Enough Multidevs
           matrix:
             parameters:
-              base-env: [dev, drupal10, drupal11]
+              base-env: [dev, drupal10]

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -27,7 +27,7 @@ composer -- require "drupal/views_custom_cache_tag:1.x-dev"
 
 # Add this project, but not via Composer
 mkdir -p web/modules/circle/pantheon_advanced_page_cache
-cp -R "$PROJECT_DIR/*" web/modules/circle/pantheon_advanced_page_cache
+cp -R "$PROJECT_DIR/"* web/modules/circle/pantheon_advanced_page_cache
 
 # Make a git commit
 git add .

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -18,7 +18,7 @@ git checkout -b $TERMINUS_ENV
 # git clone command above.
 composer update "pantheon-upstreams/upstream-configuration"
 
-composer -- config repositories.papc vcs git@github.com:pantheon-systems/pantheon_advanced_page_cache.git
+composer -- config repositories.papc vcs https://github.com/pantheon-systems/pantheon_advanced_page_cache.git
 
 # dev-2.x does not match anything, should be 2.x-dev as per https://getcomposer.org/doc/articles/aliases.md#branch-alias.
 export BRANCH_PART="dev-${CIRCLE_BRANCH}"

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -22,12 +22,17 @@ git checkout -b $TERMINUS_ENV
 # git clone command above.
 composer update "pantheon-upstreams/upstream-configuration"
 
-# Composer require views_custom_cache_tag
+# Add views_custom_cache_tag
 composer -- require "drupal/views_custom_cache_tag:1.x-dev"
 
-# Add this project, but not via Composer
-mkdir -p web/modules/circle/pantheon_advanced_page_cache
-rsync -av --exclude='vendor' --exclude='drupal-site' "$PROJECT_DIR/"* web/modules/circle/pantheon_advanced_page_cache
+# Make a copy of this project and rename it to use in a path repository
+mkdir -p /tmp/pantheon_advanced_page_cache
+rsync -av --exclude='vendor' --exclude='drupal-site' "$PROJECT_DIR/"* /tmp/pantheon_advanced_page_cache
+sed -e 's#"name": "drupal/pantheon_advanced_page_cache"#"name": "local-path/pantheon_advanced_page_cache"#' "$PROJECT_DIR/composer.json" > /tmp/pantheon_advanced_page_cache/composer.json
+
+# Require via Composer, in case we need to require any dependencies in the future & etc.
+composer -- config repositories.papc path /tmp/pantheon_advanced_page_cache
+composer -- require "local-path/pantheon_advanced_page_cache"
 
 # Make a git commit
 git add .

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -26,12 +26,12 @@ composer update "pantheon-upstreams/upstream-configuration"
 composer -- require "drupal/views_custom_cache_tag:1.x-dev"
 
 # Make a copy of this project and rename it to use in a path repository
-mkdir -p /tmp/pantheon_advanced_page_cache
-rsync -av --exclude='vendor' --exclude='drupal-site' "$PROJECT_DIR/"* /tmp/pantheon_advanced_page_cache
-sed -e 's#"name": "drupal/pantheon_advanced_page_cache"#"version": "dev-circle", "name": "local-path/pantheon_advanced_page_cache"#' "$PROJECT_DIR/composer.json" > /tmp/pantheon_advanced_page_cache/composer.json
+mkdir -p path-repositories/pantheon_advanced_page_cache
+rsync -av --exclude='vendor' --exclude='drupal-site' "$PROJECT_DIR/"* path-repositories/pantheon_advanced_page_cache
+sed -e 's#"name": "drupal/pantheon_advanced_page_cache"#"version": "dev-circle", "name": "local-path/pantheon_advanced_page_cache"#' "$PROJECT_DIR/composer.json" > path-repositories/pantheon_advanced_page_cache/composer.json
 
 # Require via Composer, in case we need to require any dependencies in the future & etc.
-composer -- config repositories.papc path /tmp/pantheon_advanced_page_cache
+composer -- config repositories.papc path path-repositories/pantheon_advanced_page_cache
 composer -- require "local-path/pantheon_advanced_page_cache: dev-circle"
 
 # Make a git commit

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -26,11 +26,8 @@ composer update "pantheon-upstreams/upstream-configuration"
 composer -- require "drupal/views_custom_cache_tag:1.x-dev"
 
 # Add this project, but not via Composer
-mkdir -p web/modules/circle
-cp -R "$PROJECT_DIR" web/modules/circle
-
-# Don't commit a submodule
-rm -rf web/modules/circle/pantheon_advanced_page_cache/.git/
+mkdir -p web/modules/circle/pantheon_advanced_page_cache
+cp -R "$PROJECT_DIR/*" web/modules/circle/pantheon_advanced_page_cache
 
 # Make a git commit
 git add .

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -28,11 +28,11 @@ composer -- require "drupal/views_custom_cache_tag:1.x-dev"
 # Make a copy of this project and rename it to use in a path repository
 mkdir -p /tmp/pantheon_advanced_page_cache
 rsync -av --exclude='vendor' --exclude='drupal-site' "$PROJECT_DIR/"* /tmp/pantheon_advanced_page_cache
-sed -e 's#"name": "drupal/pantheon_advanced_page_cache"#"name": "local-path/pantheon_advanced_page_cache"#' "$PROJECT_DIR/composer.json" > /tmp/pantheon_advanced_page_cache/composer.json
+sed -e 's#"name": "drupal/pantheon_advanced_page_cache"#"version": "dev-circle", "name": "local-path/pantheon_advanced_page_cache"#' "$PROJECT_DIR/composer.json" > /tmp/pantheon_advanced_page_cache/composer.json
 
 # Require via Composer, in case we need to require any dependencies in the future & etc.
 composer -- config repositories.papc path /tmp/pantheon_advanced_page_cache
-composer -- require "local-path/pantheon_advanced_page_cache"
+composer -- require "local-path/pantheon_advanced_page_cache: dev-circle"
 
 # Make a git commit
 git add .

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -2,6 +2,10 @@
 set -e
 export TERMINUS_ENV=$CIRCLE_BUILD_NUM
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+CIRCLE_DIR=$("$(dirname -- "${SCRIPT_DIR}")")
+PROJECT_DIR=$("$(dirname -- "${CIRCLE_DIR}")")
+
 if [ "$TERMINUS_BASE_ENV" = "dev" ]; then
   export TERMINUS_BASE_ENV=master
 fi
@@ -18,18 +22,15 @@ git checkout -b $TERMINUS_ENV
 # git clone command above.
 composer update "pantheon-upstreams/upstream-configuration"
 
-composer -- config repositories.papc vcs https://github.com/pantheon-systems/pantheon_advanced_page_cache.git
+# Composer require views_custom_cache_tag
+composer -- require "drupal/views_custom_cache_tag:1.x-dev"
 
-# dev-2.x does not match anything, should be 2.x-dev as per https://getcomposer.org/doc/articles/aliases.md#branch-alias.
-export BRANCH_PART="dev-${CIRCLE_BRANCH}"
-if [ $CIRCLE_BRANCH = "2.x" ]; then
-  export BRANCH_PART="2.x-dev"
-fi
-# Composer require the given commit of this module
-composer -- require "drupal/views_custom_cache_tag:1.x-dev" "drupal/pantheon_advanced_page_cache:${BRANCH_PART}#${CIRCLE_SHA1}"
+# Add this project, but not via Composer
+mkdir -p web/modules/circle
+cp -R "$PROJECT_DIR" web/modules/circle
 
 # Don't commit a submodule
-rm -rf web/modules/contrib/pantheon_advanced_page_cache/.git/
+rm -rf web/modules/circle/pantheon_advanced_page_cache/.git/
 
 # Make a git commit
 git add .

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -3,8 +3,8 @@ set -e
 export TERMINUS_ENV=$CIRCLE_BUILD_NUM
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-CIRCLE_DIR=$("$(dirname -- "${SCRIPT_DIR}")")
-PROJECT_DIR=$("$(dirname -- "${CIRCLE_DIR}")")
+CIRCLE_DIR="$(dirname -- "${SCRIPT_DIR}")"
+PROJECT_DIR="$(dirname -- "${CIRCLE_DIR}")"
 
 if [ "$TERMINUS_BASE_ENV" = "dev" ]; then
   export TERMINUS_BASE_ENV=master

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -11,8 +11,8 @@ if [ "$TERMINUS_BASE_ENV" = "dev" ]; then
 fi
 
 # Bring the code down to Circle so that modules can be added via composer.
-git clone $(terminus connection:info ${TERMINUS_SITE}.dev --field=git_url) --branch $TERMINUS_BASE_ENV "$HOME/drupal-site"
-cd "$HOME/drupal-site"
+git clone $(terminus connection:info ${TERMINUS_SITE}.dev --field=git_url) --branch $TERMINUS_BASE_ENV drupal-site
+cd drupal-site
 
 git checkout -b $TERMINUS_ENV
 
@@ -27,7 +27,7 @@ composer -- require "drupal/views_custom_cache_tag:1.x-dev"
 
 # Add this project, but not via Composer
 mkdir -p web/modules/circle/pantheon_advanced_page_cache
-cp -R "$PROJECT_DIR/"* web/modules/circle/pantheon_advanced_page_cache
+rsync -av --exclude='vendor' --exclude='drupal-site' "$PROJECT_DIR/"* web/modules/circle/pantheon_advanced_page_cache
 
 # Make a git commit
 git add .

--- a/.circleci/scripts/setup-drupal-repo.sh
+++ b/.circleci/scripts/setup-drupal-repo.sh
@@ -11,8 +11,8 @@ if [ "$TERMINUS_BASE_ENV" = "dev" ]; then
 fi
 
 # Bring the code down to Circle so that modules can be added via composer.
-git clone $(terminus connection:info ${TERMINUS_SITE}.dev --field=git_url) --branch $TERMINUS_BASE_ENV drupal-site
-cd drupal-site
+git clone $(terminus connection:info ${TERMINUS_SITE}.dev --field=git_url) --branch $TERMINUS_BASE_ENV "$HOME/drupal-site"
+cd "$HOME/drupal-site"
 
 git checkout -b $TERMINUS_ENV
 

--- a/pantheon_advanced_page_cache.info.yml
+++ b/pantheon_advanced_page_cache.info.yml
@@ -2,4 +2,5 @@ name: Pantheon Advanced Page Cache
 description: 'Advanced page cache capabilities for Pantheon.'
 package: Performance and scalability
 type: module
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.4 || ^10 || ^11
+

--- a/pantheon_advanced_page_cache.module
+++ b/pantheon_advanced_page_cache.module
@@ -19,7 +19,7 @@ function pantheon_advanced_page_cache_file_update(EntityInterface $file) {
 
   // If this is an image, we need to clear the edge cache paths for every
   // image style, or those won't work.
-  if (strpos($file->getMimeType(), 'image', 0) === 0) {
+  if ((class_exists(ImageStyle)) && (strpos($file->getMimeType(), 'image', 0) === 0)) {
     $styles = ImageStyle::loadMultiple();
     foreach ($styles as $style) {
       $file_uri = $file->getFileUri();

--- a/tests/behat/features/huge_header_warning.feature
+++ b/tests/behat/features/huge_header_warning.feature
@@ -5,7 +5,6 @@ I need a notification when my header is truncated.
 
   @api
   Scenario: Warning message.
-    Given I run drush "pm-uninstall -y pantheon_advanced_page_cache_test"
     Given I run drush "en -y pantheon_advanced_page_cache"
     And I am logged in as a user with the "administrator" role
 

--- a/tests/behat/features/override_list_tag.feature
+++ b/tests/behat/features/override_list_tag.feature
@@ -6,7 +6,8 @@ I want to toggle the setting for overriding cache tags
   @api
   Scenario: Core behavior
     Given there are some "article" nodes
-    And "/" is caching
+    When I visit "/"
+    Then "/" is caching
     When a generate a "article" node
     Then "/" has been purged
     And "/" is caching
@@ -15,7 +16,7 @@ I want to toggle the setting for overriding cache tags
   Scenario: Old override
     Given there are some "article" nodes
     When I run drush "config:set pantheon_advanced_page_cache.settings --input-format=yaml   override_list_tags true"
-    And "/" is caching
+    And I visit "/"
+    Then "/" is caching
     When a generate a "article" node
-    And "/" has not been purged
-
+    Then "/" has not been purged

--- a/tests/modules/pantheon_advanced_page_cache_test/pantheon_advanced_page_cache_test.info.yml
+++ b/tests/modules/pantheon_advanced_page_cache_test/pantheon_advanced_page_cache_test.info.yml
@@ -2,4 +2,4 @@ name: Pantheon Advanced Page Cache Test
 description: 'Used during automated test of Pantheon Advanced Page Cache'
 package: Testing
 type: module
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.4 || ^10 || ^11


### PR DESCRIPTION
Continuation of #57

Behat tests are failing for Drupal 11; for some reason, the cache headers always come back with age=0 when running under Behat with Drupal 11. PAPC seems to be working fine with D11 in ad-hoc testing, though.