### PR TITLE
[SITE-1855] Fix error in module that breaks all image operations

### DIFF
--- a/pantheon_advanced_page_cache.module
+++ b/pantheon_advanced_page_cache.module
@@ -19,7 +19,7 @@ function pantheon_advanced_page_cache_file_update(EntityInterface $file) {
 
   // If this is an image, we need to clear the edge cache paths for every
   // image style, or those won't work.
-  if ((class_exists(ImageStyle)) && (strpos($file->getMimeType(), 'image', 0) === 0)) {
+  if ((class_exists(ImageStyle::class)) && (strpos($file->getMimeType(), 'image', 0) === 0)) {
     $styles = ImageStyle::loadMultiple();
     foreach ($styles as $style) {
       $file_uri = $file->getFileUri();


### PR DESCRIPTION
I reproduced the error in the release (WSOD when saving a node with embedded images), and then pushed this fix to the site and confirmed that image uploads work again.