### PR TITLE
[SITE-4998] Fix strpos() deprecated warning in PHP8+

### DIFF
--- a/pantheon_advanced_page_cache.module
+++ b/pantheon_advanced_page_cache.module
@@ -23,7 +23,7 @@ function pantheon_advanced_page_cache_file_update(EntityInterface $file) {
 
   // If this is an image, we need to clear the edge cache paths for every
   // image style, or those won't work.
-  if ((class_exists(ImageStyle::class)) && $file->getMimeType() !== NULL && ((strpos($file->getMimeType(), 'image', 0) === 0)) {
+  if ((class_exists(ImageStyle::class)) && $file->getMimeType() !== NULL && (strpos($file->getMimeType(), 'image', 0) === 0)) {
     $styles = ImageStyle::loadMultiple();
     foreach ($styles as $style) {
       $file_uri = $file->getFileUri();

--- a/pantheon_advanced_page_cache.module
+++ b/pantheon_advanced_page_cache.module
@@ -23,7 +23,7 @@ function pantheon_advanced_page_cache_file_update(EntityInterface $file) {
 
   // If this is an image, we need to clear the edge cache paths for every
   // image style, or those won't work.
-  if ((class_exists(ImageStyle::class)) && $file->getMimeType() !== null && ((strpos($file->getMimeType(), 'image', 0) === 0)) {
+  if ((class_exists(ImageStyle::class)) && $file->getMimeType() !== NULL && ((strpos($file->getMimeType(), 'image', 0) === 0)) {
     $styles = ImageStyle::loadMultiple();
     foreach ($styles as $style) {
       $file_uri = $file->getFileUri();

--- a/pantheon_advanced_page_cache.module
+++ b/pantheon_advanced_page_cache.module
@@ -23,7 +23,7 @@ function pantheon_advanced_page_cache_file_update(EntityInterface $file) {
 
   // If this is an image, we need to clear the edge cache paths for every
   // image style, or those won't work.
-  if ((class_exists(ImageStyle::class)) && (strpos($file->getMimeType(), 'image', 0) === 0)) {
+  if ((class_exists(ImageStyle::class)) && $file->getMimeType() !== null && ((strpos($file->getMimeType(), 'image', 0) === 0)) {
     $styles = ImageStyle::loadMultiple();
     foreach ($styles as $style) {
       $file_uri = $file->getFileUri();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="pantheon_advanced_page_cache">
-  <description>Default PHP CodeSniffer configuration for the search_api_pantheon module.</description>
+  <description>Default PHP CodeSniffer configuration for the Pantheon Advanced Page Cache module.</description>
   <arg name="extensions" value="inc,install,module,php,profile,test,theme,yml"/>
   <!--Exclude third party code.-->
   <exclude-pattern>./vendor/*</exclude-pattern>


### PR DESCRIPTION
This PR implements the fix for issue reported in drupal.org https://www.drupal.org/project/pantheon_advanced_page_cache/issues/3448573.
it adds a null check before calling strpos() to avoid potential errors when the MIME type is null. 
I was unable to reproduce the issue in module version 2.2.0 or the latest release (2.3.0). I tested using Drupal 9,10,11 with PHP 8.2-8.4.

Tested the issue using static analysis tools and attempted to trigger the error by adding and then removing an image from an article, but none of these steps led to the reported behavior.

However, since the issue may still occur in specific edge cases or configurations that were not covered during testing, i'm applying the patch added by the drupal community.
