### PR TITLE
[SITE-6002] Fix CodeQL alerts

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,6 +2,9 @@ name: Mirror code on D.org
 on:
   push:
 
+permissions:
+  contents: read
+
 concurrency:
   group: 'ci-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to the mirror workflow. Without a permissions block, the workflow runs with the default token permissions, which is broader than necessary. This resolves the CodeQL `missing-workflow-permissions` alert.

## Test plan

- [ ] Verify the mirror workflow still works on push
- [ ] Confirm CodeQL alert is resolved